### PR TITLE
Stringified keyboard constants redux

### DIFF
--- a/ex/rlt-01.pl
+++ b/ex/rlt-01.pl
@@ -29,22 +29,22 @@ class Engine {
         key_map => {
 
             # vim keys
-            KEY_H() => sub { $player_x -= 10 },
-            KEY_L() => sub { $player_x += 10 },
-            KEY_K() => sub { $player_y -= 10 },
-            KEY_J() => sub { $player_y += 10 },
+            KEY_H => sub { $player_x -= 10 },
+            KEY_L => sub { $player_x += 10 },
+            KEY_K => sub { $player_y -= 10 },
+            KEY_J => sub { $player_y += 10 },
 
             # wasd keys
-            KEY_W() => sub { $player_y -= 10 },
-            KEY_S() => sub { $player_y += 10 },
-            KEY_A() => sub { $player_x -= 10 },
-            KEY_D() => sub { $player_x += 10 },
+            KEY_W => sub { $player_y -= 10 },
+            KEY_S => sub { $player_y += 10 },
+            KEY_A => sub { $player_x -= 10 },
+            KEY_D => sub { $player_x += 10 },
 
             # arrow keys
-            KEY_UP()    => sub { $player_y -= 10 },
-            KEY_DOWN()  => sub { $player_y += 10 },
-            KEY_LEFT()  => sub { $player_x -= 10 },
-            KEY_RIGHT() => sub { $player_x += 10 },
+            KEY_UP    => sub { $player_y -= 10 },
+            KEY_DOWN  => sub { $player_y += 10 },
+            KEY_LEFT  => sub { $player_x -= 10 },
+            KEY_RIGHT => sub { $player_x += 10 },
         },
     );
 

--- a/ex/rlt-01.pl
+++ b/ex/rlt-01.pl
@@ -41,10 +41,10 @@ class Engine {
             KEY_D => sub { $player_x += 10 },
 
             # arrow keys
-            KEY_UP    => sub { $player_y -= 10 },
-            KEY_DOWN  => sub { $player_y += 10 },
-            KEY_LEFT  => sub { $player_x -= 10 },
-            KEY_RIGHT => sub { $player_x += 10 },
+            UP    => sub { $player_y -= 10 },
+            DOWN  => sub { $player_y += 10 },
+            LEFT  => sub { $player_x -= 10 },
+            RIGHT => sub { $player_x += 10 },
         },
     );
 

--- a/ex/rlt-02.pl
+++ b/ex/rlt-02.pl
@@ -162,22 +162,22 @@ class Engine {
             key_map => {
 
                 # vim keys
-                KEY_H() => sub { movement_action( -1, 0 ) },
-                KEY_L() => sub { movement_action( 1,  0 ) },
-                KEY_K() => sub { movement_action( 0,  -1 ) },
-                KEY_J() => sub { movement_action( 0,  1 ) },
+                KEY_H => sub { movement_action( -1, 0 ) },
+                KEY_L => sub { movement_action( 1,  0 ) },
+                KEY_K => sub { movement_action( 0,  -1 ) },
+                KEY_J => sub { movement_action( 0,  1 ) },
 
                 # wasd keys
-                KEY_W() => sub { movement_action( 0,  -1 ) },
-                KEY_S() => sub { movement_action( 0,  1 ) },
-                KEY_A() => sub { movement_action( -1, 0 ) },
-                KEY_D() => sub { movement_action( 1,  0 ) },
+                KEY_W => sub { movement_action( 0,  -1 ) },
+                KEY_S => sub { movement_action( 0,  1 ) },
+                KEY_A => sub { movement_action( -1, 0 ) },
+                KEY_D => sub { movement_action( 1,  0 ) },
 
                 # arrow keys
-                KEY_UP()    => sub { movement_action( 0,  -1 ) },
-                KEY_DOWN()  => sub { movement_action( 0,  1 ) },
-                KEY_LEFT()  => sub { movement_action( -1, 0 ) },
-                KEY_RIGHT() => sub { movement_action( 1,  0 ) },
+                KEY_UP    => sub { movement_action( 0,  -1 ) },
+                KEY_DOWN  => sub { movement_action( 0,  1 ) },
+                KEY_LEFT  => sub { movement_action( -1, 0 ) },
+                KEY_RIGHT => sub { movement_action( 1,  0 ) },
             },
         )
     }

--- a/ex/test.pl
+++ b/ex/test.pl
@@ -1,6 +1,6 @@
 use 5.36.3;
 use lib qw(lib);
-use Raylib::FFI;
+use Raylib::FFI ':all';
 use constant Color => 'Raylib::FFI::Color';
 
 InitWindow( 800, 600, "Testing!" );

--- a/lib/Raylib/Keyboard.pm
+++ b/lib/Raylib/Keyboard.pm
@@ -2,7 +2,8 @@ use 5.36.3;
 use Feature::Compat::Class;
 
 class Raylib::Keyboard {
-    use Raylib::FFI;
+    use Raylib::FFI qw( GetKeyPressed );
+    use Carp qw( carp );
     our %key_map;
 
     BEGIN {
@@ -130,15 +131,25 @@ class Raylib::Keyboard {
         *key_pressed  = &Raylib::FFI::GetKeyPressed;
     }
 
-    our @EXPORT_OK( keys %key_map );
-
     field $key_map :param = {};
+    field $key_const_map = {};
 
     method handle_events() {
         while ( my $key = GetKeyPressed() ) {
-            next unless $key_map->{$key};
-            $key_map->{$key}->();
+            next unless $key_const_map->{$key};
+            $key_const_map->{$key}->();
+        }
+    }
+
+    ADJUST {
+        for my ( $key, $sub ) ( $key_map->%* ) {
+            if ( !$self->can( $key ) ) {
+                carp "Unrecognised key $key";
+                next;
+            }
+            $key_const_map->{ $self->$key } = $sub
         }
     }
 }
 
+1;

--- a/lib/Raylib/Keyboard.pm
+++ b/lib/Raylib/Keyboard.pm
@@ -3,6 +3,7 @@ use Feature::Compat::Class;
 
 class Raylib::Keyboard {
     use Raylib::FFI qw( GetKeyPressed );
+    use Scalar::Util qw( looks_like_number );
     use Carp qw( carp );
     our %key_map;
 
@@ -143,7 +144,9 @@ class Raylib::Keyboard {
 
     ADJUST {
         for my ( $key, $sub ) ( $key_map->%* ) {
-            my $const = $self->can( $key ) // $self->can( "KEY_$key" );
+            my $const = looks_like_number( $key )
+                ? sub { $key }
+                : $self->can( $key ) // $self->can( "KEY_$key" );
             if ( ! $const ) {
                 carp "Unrecognised key $key";
                 next;

--- a/lib/Raylib/Keyboard.pm
+++ b/lib/Raylib/Keyboard.pm
@@ -143,11 +143,12 @@ class Raylib::Keyboard {
 
     ADJUST {
         for my ( $key, $sub ) ( $key_map->%* ) {
-            if ( !$self->can( $key ) ) {
+            my $const = $self->can( $key ) // $self->can( "KEY_$key" );
+            if ( ! $const ) {
                 carp "Unrecognised key $key";
                 next;
             }
-            $key_const_map->{ $self->$key } = $sub
+            $key_const_map->{ $const->() } = $sub
         }
     }
 }

--- a/lib/Raylib/Text.pm
+++ b/lib/Raylib/Text.pm
@@ -2,7 +2,7 @@ use 5.36.3;
 use Feature::Compat::Class;
 
 class Raylib::Text {
-    use Raylib::FFI;
+    use Raylib::FFI qw( DrawText );
 
     field $text : param;
     field $color : param;


### PR DESCRIPTION
I started with the intent of fixing build errors in Keyboard.pm and wound up here - I did not set out to recreate #4.

I'm honestly not sure how one makes new-style classes also be an Exporter, so I removed `@EXPORT_OK`, and created an `ADJUST` block to look up stringy key constants passed in `$key_map`.

There are other minor changes, mainly to imports - everything in ex/ now appears to build and run.