### PR TITLE
Ad-hoc bindings - BYO function defs

### DIFF
--- a/ex/attach.pl
+++ b/ex/attach.pl
@@ -17,8 +17,8 @@ while ( !WindowShouldClose() ) {
     ClearBackground( Raylib::Color::BLACK );
     BeginDrawing();
     rlTranslatef( 400, 300 );
-    rotate($r+=3, 0, 0, -1);
-    DrawText( "Weeee!", 0, 0, 40, Raylib::Color::WHITE);
+    rotate( $r += 3, 0, 0, -1 );
+    DrawText( "Weeee!", 0, 0, 40, Raylib::Color::WHITE );
     EndDrawing();
 }
 

--- a/ex/attach.pl
+++ b/ex/attach.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+use 5.36.3;
+use lib qw(lib);
+
+use Raylib::FFI ':all';
+use Raylib::Color;
+
+Raylib::FFI::attach( rlTranslatef              => [ ( 'float' ) x 3 ] );
+Raylib::FFI::attach( [ rlRotatef => 'rotate' ] => [ ( 'float' ) x 4 ] );
+Raylib::FFI->import( qw( rlTranslatef rotate ) );
+
+InitWindow( 800, 600, "Testing!" );
+SetTargetFPS(60);
+
+my $r = 0;
+while ( !WindowShouldClose() ) {
+    ClearBackground( Raylib::Color::BLACK );
+    BeginDrawing();
+    rlTranslatef( 400, 300 );
+    rotate($r+=3, 0, 0, -1);
+    DrawText( "Weeee!", 0, 0, 40, Raylib::Color::WHITE);
+    EndDrawing();
+}
+

--- a/lib/Raylib/FFI.pm
+++ b/lib/Raylib/FFI.pm
@@ -1114,6 +1114,14 @@ for my $func ( keys %functions ) {
 # export all the functions lexically
 our @EXPORT_OK = grep { __PACKAGE__->can($_) } keys %functions;
 our %EXPORT_TAGS = (all => \@EXPORT_OK);
+
+sub attach {
+    my $name = shift;
+    $ffi->attach( $name => @_ );
+    my $perl_name = ref $name eq 'ARRAY' ? $name->[1] : $name;
+    push @EXPORT_OK, $perl_name;
+}
+
 1;
 
 __END__
@@ -3204,6 +3212,29 @@ Set pan for audio stream (0.5 is center)
 =head2 SetAudioStreamBufferSizeDefault( $size )
 
 Default size for new audio streams
+
+=head1 Ad-hoc binding
+
+Binding to the most commonly used Raylib functions is provided by this module.
+However, Raylib's API includes hundreds of functions not explicitly defined
+here which may prove useful, e.g. those in the
+L<rlgl module|https://github.com/raysan5/raylib/blob/master/src/rlgl.h>.
+
+=head2 attach
+
+A function called attach is provided (though not exported) which allows you to
+bind additional Raylib functions at run-time. These functions may then be
+imported to your namespace.
+
+This works identically to L<FFI::Platypus/attach>:
+
+    use Raylib::FFI ':all';
+
+    Raylib::FFI::attach( rlTranslatef => [ ( 'float' ) x 3 ] );
+    Raylib::FFI->import( qw( rlTranslatef ) );
+
+    # use rlTranslatef() here
+
 
 =head1 KNOWN ISSUES
 


### PR DESCRIPTION
This started out with an eye to binding rlgl.h (mostly for the rotate and transform pieces), but there are over 150 exported functions there and its not clear upfront which are the most useful - I think most of what's in that header is perhaps not all that useful to the Perl game developer.

...so here we are. BYO bindings for rare pieces outside the set of generally useful things - an `attach` function which acts as a small wrapper around the `$ffi` instance attach.